### PR TITLE
Add helper to generate 32 byte random strings.

### DIFF
--- a/test-helpers.bash
+++ b/test-helpers.bash
@@ -157,3 +157,13 @@ function check_remote_file_exists() {
         fail "remote file does not exist: $1"
     fi
 }
+
+# this function is used to create a unique string used to uniquely identify messages.
+function random_string() {
+	local chars=abcdefghijklmnopqrstuvwxyz0123456890
+	# shellcheck disable=SC2034
+	for i in {1..32} ; do
+		echo -n "${chars:RANDOM%${#chars}:1}" | sha256sum | cut -f1 -d' '
+	done
+	echo
+}


### PR DESCRIPTION
This is usually used to generate output that can be easy and reliable to check against.