### PR TITLE
fix: suppress docker log SIGPIPE from causing false negative.

### DIFF
--- a/test-helpers.bash
+++ b/test-helpers.bash
@@ -140,7 +140,7 @@ function wait_for_container_output() {
     fi
 
     # Note for failing containers, logs go to stderr
-    until "$CONTAINER_RUNTIME" logs "$CONTAINER_NAME" 2>&1 |grep -qF "$EXPECTED_OUTPUT" ; do
+    until ("$CONTAINER_RUNTIME" logs "$CONTAINER_NAME" || :) 2>&1 | grep -qF "$EXPECTED_OUTPUT" ; do
         # Prevent an infinite loop - at 5 seconds per go this is 10 minutes
         if [ $ATTEMPTS -gt "120" ]; then
             fail "wait_for_container_output ultimate max exceeded: \"$EXPECTED_OUTPUT\" ($*)"


### PR DESCRIPTION
The until loop in `wait_for_container_output` can fail when `grep` exists early. This happens because `grep` will close immediately, leaving the `docker logs` command nowhere to write resulting in a SIGPIPE which sets the return code to 141.

References:

- https://www.gangofcoders.net/solution/why-exit-code-141-with-grep-q/
- https://unix.stackexchange.com/questions/582844/how-to-suppress-sigpipe-in-bash